### PR TITLE
BeanstalkSourceStageS3BucketKey parameter is not an optional parameter

### DIFF
--- a/templates/bluegreen-deployment-master.template
+++ b/templates/bluegreen-deployment-master.template
@@ -200,7 +200,7 @@
         },
         "BeanstalkSourceStageS3BucketKey": {
             "Default": "",
-            "Description": "(Optional) The path to the Elastic Beanstalk application source package (in .zip format) that will trigger the source stage in the pipeline. If the GitToS3integration parameter is set to true, this parameter is the S3 bucket key where the Git webhook will place the zip file as input to the source stage in the pipeline. The key should be in the format git-user/git-repository/git-user_git-repository.zip. This value differs from one Git repo to another. For more information, see the deployment steps in the Git Webhooks with AWS Services Quick Start deployment guide.",
+            "Description": "The path to the Elastic Beanstalk application source package (in .zip format) that will trigger the source stage in the pipeline. If the GitToS3integration parameter is set to true, this parameter is the S3 bucket key where the Git webhook will place the zip file as input to the source stage in the pipeline. The key should be in the format git-user/git-repository/git-user_git-repository.zip. This value differs from one Git repo to another. For more information, see the deployment steps in the Git Webhooks with AWS Services Quick Start deployment guide.",
             "Type": "String"
         },
         "BeanstalkSourceStageS3BucketName": {


### PR DESCRIPTION
This is a required parameter. Updated this in this pull request