### PR TITLE
Add a parameter UrlSwapCodeBuildServerName to remove hardcoded value

### DIFF
--- a/templates/bluegreen-deployment-master.template
+++ b/templates/bluegreen-deployment-master.template
@@ -23,6 +23,7 @@ Metadata:
         Parameters:
           - AdministratorEmail
           - NameofthePipeline
+          - UrlSwapCodeBuildServerName
       - Label:
           default: Git2s3 setup parameters. Valid only when GitToS3integration parameter
             is set to true. Ignore otherwise.
@@ -66,6 +67,8 @@ Metadata:
         default: Quick Start S3 bucket region
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      UrlSwapCodeBuildServerName:
+        default: Url Swap CodeBuild Server Name
 Conditions:
   CreateBeanstalkStack: !Or
     - !Condition 'CreateNewBeanstalkEnv'
@@ -223,6 +226,10 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
     Type: String
+  UrlSwapCodeBuildServerName:
+    Default: 'CICDurlSwap'
+    Description: Url swap CodeBuild server name
+    Type: String
 Rules:
   CheckforBeanstalkSourceBucketKey:
     RuleCondition: !Equals
@@ -331,6 +338,7 @@ Resources:
             - !GetAtt 'CopyFunctiontoS3BucketStack.Outputs.BeanstalkSourceBucket'
             - !Ref 'BeanstalkSourceStageS3BucketName'
         CodePipelineArtifactStore: !GetAtt 'CopyFunctiontoS3BucketStack.Outputs.CodePipelineArtifactStore'
+        UrlSwapCodeBuildServerName: !Ref 'UrlSwapCodeBuildServerName'
 Outputs:
   NewBeanstalkEnvEndPointUrl:
     Condition: CreateNewBeanstalkEnv

--- a/templates/codepipeline-stack.template
+++ b/templates/codepipeline-stack.template
@@ -56,6 +56,9 @@ Parameters:
       can include numbers, lowercase letters, uppercase letters, hyphens (-), and
       forward slash (/).
     Type: String
+  UrlSwapCodeBuildServerName:
+    Description: Url swap CodeBuild server name
+    Type: String
 Resources:
   BlueGreenCICDPipeline:
     Properties:
@@ -284,7 +287,7 @@ Resources:
             Value: bluecnameconfig.json
         Image: aws/codebuild/ubuntu-base:14.04
         Type: LINUX_CONTAINER
-      Name: CICDurlSwap
+      Name: !Ref UrlSwapCodeBuildServerName
       ServiceRole: !GetAtt 'BuildServiceRole.Arn'
       Source:
         Type: CODEPIPELINE


### PR DESCRIPTION
*Issue #, if available:* 9 
https://github.com/aws-quickstart/quickstart-codepipeline-bluegreen-deployment/issues/9
*Description of changes:* Add a new parameter to remove hardcoded value and hence provide flexibility


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
