### PR TITLE
Updated min python version to 3.7. Changed solution stack to PHP 8.0

### DIFF
--- a/templates/bluegreen-deployment-master.template
+++ b/templates/bluegreen-deployment-master.template
@@ -99,7 +99,7 @@ Mappings:
     php:
       NewBlueEnvironmentName: BlueEnvironment
       NewBeanstalkApplicationName: BlueGreenBeanstalkApplication
-      SolutionStackForNewBeanstalkEnv: 64bit Amazon Linux 2 v3.3.1 running PHP 7.4
+      SolutionStackForNewBeanstalkEnv: 64bit Amazon Linux 2 v3.5.0 running PHP 8.0
       AppPackageS3Bucket: elasticbeanstalk-samples
       AppPackageS3key: php-sample.zip
 Parameters:

--- a/templates/codepipeline-stack.template
+++ b/templates/codepipeline-stack.template
@@ -322,7 +322,7 @@ Resources:
         S3Key: !Sub ${QSS3KeyPrefix}functions/packages/CreateEnvironment/creategreenenv.zip
       Handler: index.handler
       Role: !GetAtt 'LambdaExecutionRole.Arn'
-      Runtime: python3.6
+      Runtime: python3.7
       Timeout: 300
     Type: AWS::Lambda::Function
   LambdaExecutionRole:
@@ -432,6 +432,6 @@ Resources:
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/TerminateandReSwap/terminategreenenv.zip'
       Handler: index.handler
       Role: !GetAtt 'LambdaExecutionRole.Arn'
-      Runtime: python3.6
+      Runtime: python3.7
       Timeout: 300
     Type: AWS::Lambda::Function

--- a/templates/elasticbeanstalk-sample.template
+++ b/templates/elasticbeanstalk-sample.template
@@ -76,7 +76,7 @@ Parameters:
       is required only when you leave the 'ExistingBlueEnvironmentName' property empty
     Type: String
   SolutionStackForNewBeanstalkEnv:
-    Default: 64bit Amazon Linux 2 v3.3.1 running PHP 7.4
+    Default: 64bit Amazon Linux 2 v3.5.0 running PHP 8.0
     Description: >-
       Provide a name for the Beanstalk Solution stack for launching the new Blue Environment.
       If not provided, the default will be a PHP solution stack. Please refer the


### PR DESCRIPTION

*Description of changes:*
Updated versions of lambda runtime and Elastic beanstalk to PHP 8.0 as old versions were deprecated and not supported for new deployments and resulted in deployment failure. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
